### PR TITLE
Avoid embedding secrets in user data scripts

### DIFF
--- a/groups/adminsites-infrastructure/data.tf
+++ b/groups/adminsites-infrastructure/data.tf
@@ -108,8 +108,9 @@ data "template_file" "ewfadmin" {
   vars = {
     REGION               = var.aws_region
     HERITAGE_ENVIRONMENT = title(var.environment)
-    FRONTEND_INPUTS      = data.vault_generic_secret.ewfadmin_data.data_json
-    ANSIBLE_INPUTS       = jsonencode(local.ewfadmin_ansible_inputs)
+    APP_VERSION          = var.ewfadmin_app_release_version
+    FRONTEND_INPUTS_PATH = "${local.parameter_store_path_prefix}/ewfadmin_frontend_inputs"
+    ANSIBLE_INPUTS_PATH  = "${local.parameter_store_path_prefix}/ewfadmin_frontend_ansible_inputs"
   }
 }
 
@@ -132,8 +133,9 @@ data "template_file" "xmladmin" {
   vars = {
     REGION               = var.aws_region
     HERITAGE_ENVIRONMENT = title(var.environment)
-    FRONTEND_INPUTS      = data.vault_generic_secret.xmladmin_data.data_json
-    ANSIBLE_INPUTS       = jsonencode(local.xmladmin_ansible_inputs)
+    APP_VERSION          = var.xmladmin_app_release_version
+    FRONTEND_INPUTS_PATH = "${local.parameter_store_path_prefix}/xmladmin_frontend_inputs"
+    ANSIBLE_INPUTS_PATH  = "${local.parameter_store_path_prefix}/xmladmin_frontend_ansible_inputs"
   }
 }
 
@@ -156,8 +158,9 @@ data "template_file" "xmloutadmin" {
   vars = {
     REGION               = var.aws_region
     HERITAGE_ENVIRONMENT = title(var.environment)
-    FRONTEND_INPUTS      = data.vault_generic_secret.xmloutadmin_data.data_json
-    ANSIBLE_INPUTS       = jsonencode(local.xmloutadmin_ansible_inputs)
+    APP_VERSION          = var.xmloutadmin_app_release_version
+    FRONTEND_INPUTS_PATH = "${local.parameter_store_path_prefix}/xmloutadmin_frontend_inputs"
+    ANSIBLE_INPUTS_PATH  = "${local.parameter_store_path_prefix}/xmloutadmin_frontend_ansible_inputs"
   }
 }
 

--- a/groups/adminsites-infrastructure/iam.tf
+++ b/groups/adminsites-infrastructure/iam.tf
@@ -19,7 +19,8 @@ module "ewfadmin_iam_profile" {
   instance_asg_arns = [module.ewfadmin_autoscaling_groups.this_autoscaling_group_arn]
   kms_key_refs = [
     "alias/${var.account}/${var.region}/ebs",
-    local.ssm_kms_key_id
+    local.ssm_kms_key_id,
+    local.account_ssm_key_arn
   ]
   s3_buckets_write = [local.session_manager_bucket_name]
   custom_statements = [
@@ -35,6 +36,14 @@ module "ewfadmin_iam_profile" {
       actions = [
         "s3:Get*",
         "s3:List*",
+      ]
+    },
+    {
+      sid       = "AllowReadOfParameterStore",
+      effect    = "Allow",
+      resources = ["arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/${var.application}/${var.environment}/*"],
+      actions = [
+        "ssm:GetParameter*"
       ]
     }
   ]
@@ -61,7 +70,8 @@ module "xmladmin_iam_profile" {
   instance_asg_arns = [module.xmladmin_autoscaling_groups.this_autoscaling_group_arn]
   kms_key_refs = [
     "alias/${var.account}/${var.region}/ebs",
-    local.ssm_kms_key_id
+    local.ssm_kms_key_id,
+    local.account_ssm_key_arn
   ]
   s3_buckets_write = [local.session_manager_bucket_name]
   custom_statements = [
@@ -77,6 +87,14 @@ module "xmladmin_iam_profile" {
       actions = [
         "s3:Get*",
         "s3:List*",
+      ]
+    },
+    {
+      sid       = "AllowReadOfParameterStore",
+      effect    = "Allow",
+      resources = ["arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/${var.application}/${var.environment}/*"],
+      actions = [
+        "ssm:GetParameter*"
       ]
     }
   ]
@@ -103,7 +121,8 @@ module "xmloutadmin_iam_profile" {
   instance_asg_arns = [module.xmloutadmin_autoscaling_groups.this_autoscaling_group_arn]
   kms_key_refs = [
     "alias/${var.account}/${var.region}/ebs",
-    local.ssm_kms_key_id
+    local.ssm_kms_key_id,
+    local.account_ssm_key_arn
   ]
   s3_buckets_write = [local.session_manager_bucket_name]
   custom_statements = [
@@ -119,6 +138,14 @@ module "xmloutadmin_iam_profile" {
       actions = [
         "s3:Get*",
         "s3:List*",
+      ]
+    },
+    {
+      sid       = "AllowReadOfParameterStore",
+      effect    = "Allow",
+      resources = ["arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/${var.application}/${var.environment}/*"],
+      actions = [
+        "ssm:GetParameter*"
       ]
     }
   ]

--- a/groups/adminsites-infrastructure/locals.tf
+++ b/groups/adminsites-infrastructure/locals.tf
@@ -6,8 +6,10 @@ locals {
   s3_releases         = data.vault_generic_secret.s3_releases.data
   adminsites_ec2_data = data.vault_generic_secret.adminsites_ec2_data.data
 
-  sns_kms_key_id              = data.vault_generic_secret.kms_keys.data["sns"]
-  logs_kms_key_id             = data.vault_generic_secret.kms_keys.data["logs"]
+  kms_keys_data               = data.vault_generic_secret.kms_keys.data
+  account_ssm_key_arn         = local.kms_keys_data["ssm"]
+  sns_kms_key_id              = local.kms_keys_data["sns"]
+  logs_kms_key_id             = local.kms_keys_data["logs"]
   ssm_kms_key_id              = data.vault_generic_secret.security_kms_keys.data["session-manager-kms-key-arn"]
   session_manager_bucket_name = data.vault_generic_secret.security_s3_buckets.data["session-manager-bucket-name"]
   elb_logs_s3_bucket_name     = data.vault_generic_secret.security_s3_buckets.data["elb-access-logs-bucket-name"]
@@ -75,6 +77,18 @@ locals {
     cw_log_files               = local.xmloutadmin_cw_logs
     cw_agent_user              = "root"
   }
+
+  parameter_store_path_prefix = "/${var.application}/${var.environment}"
+
+  parameter_store_secrets = {
+    ewfadmin_frontend_inputs            = data.vault_generic_secret.ewfadmin_data.data_json
+    ewfadmin_frontend_ansible_inputs    = jsonencode(local.ewfadmin_ansible_inputs)
+    xmladmin_frontend_inputs            = data.vault_generic_secret.xmladmin_data.data_json
+    xmladmin_frontend_ansible_inputs    = jsonencode(local.xmladmin_ansible_inputs)
+    xmloutadmin_frontend_inputs         = data.vault_generic_secret.xmloutadmin_data.data_json
+    xmloutadmin_frontend_ansible_inputs = jsonencode(local.xmloutadmin_ansible_inputs)
+  }
+
   ################################
 
   default_tags = {

--- a/groups/adminsites-infrastructure/parameter-store.tf
+++ b/groups/adminsites-infrastructure/parameter-store.tf
@@ -1,0 +1,13 @@
+resource "aws_ssm_parameter" "parameters" {
+  for_each = local.parameter_store_secrets
+
+  name   = "${local.parameter_store_path_prefix}/${each.key}"
+  type   = "SecureString"
+  value  = each.value
+  key_id = local.account_ssm_key_arn
+
+  tags = {
+    Environment = var.environment
+    Application = var.application
+  }
+}

--- a/groups/adminsites-infrastructure/templates/ewfadmin_user_data.tpl
+++ b/groups/adminsites-infrastructure/templates/ewfadmin_user_data.tpl
@@ -2,10 +2,10 @@
 # Redirect the user-data output to the console logs
 exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 
+GET_PARAM_COMMAND="/usr/local/bin/aws ssm get-parameter --with-decryption --region ${REGION} --output text --query Parameter.Value --name"
+
 #Create key:value variable
-cat <<EOF >>inputs.json
-${FRONTEND_INPUTS}
-EOF
+$${GET_PARAM_COMMAND} '${FRONTEND_INPUTS_PATH}' > inputs.json
 #Update Nagios registration script with relevant template
 cp /usr/local/bin/nagios-host-add.sh /usr/local/bin/nagios-host-add.j2
 REPLACE=Admin_Site_${HERITAGE_ENVIRONMENT} /usr/local/bin/j2 /usr/local/bin/nagios-host-add.j2 > /usr/local/bin/nagios-host-add.sh
@@ -18,4 +18,6 @@ rm /etc/httpd/conf.d/perl.conf
 #Create and populate httpd config
 /usr/local/bin/j2 -f json /etc/httpd/conf/ewfadmin.httpd.conf.j2 inputs.json > /etc/httpd/conf/httpd.conf
 #Run Ansible playbook for Frontend deployment using provided inputs
-/usr/local/bin/ansible-playbook /root/ewfadmin_deployment.yml -e '${ANSIBLE_INPUTS}'
+$${GET_PARAM_COMMAND} '${ANSIBLE_INPUTS_PATH}' > /root/ansible_inputs.json
+echo "Deploying ${APP_VERSION}"
+/usr/local/bin/ansible-playbook /root/ewfadmin_deployment.yml -e '@/root/ansible_inputs.json'

--- a/groups/adminsites-infrastructure/templates/xmladmin_user_data.tpl
+++ b/groups/adminsites-infrastructure/templates/xmladmin_user_data.tpl
@@ -2,10 +2,10 @@
 # Redirect the user-data output to the console logs
 exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 
+GET_PARAM_COMMAND="/usr/local/bin/aws ssm get-parameter --with-decryption --region ${REGION} --output text --query Parameter.Value --name"
+
 #Create key:value variable
-cat <<EOF >>inputs.json
-${FRONTEND_INPUTS}
-EOF
+$${GET_PARAM_COMMAND} '${FRONTEND_INPUTS_PATH}' > inputs.json
 #Update Nagios registration script with relevant template
 cp /usr/local/bin/nagios-host-add.sh /usr/local/bin/nagios-host-add.j2
 REPLACE=Admin_Site_${HERITAGE_ENVIRONMENT} /usr/local/bin/j2 /usr/local/bin/nagios-host-add.j2 > /usr/local/bin/nagios-host-add.sh
@@ -18,4 +18,6 @@ rm /etc/httpd/conf.d/perl.conf
 #Create and populate httpd config
 /usr/local/bin/j2 -f json /etc/httpd/conf/xmladmin.httpd.conf.j2 inputs.json > /etc/httpd/conf/httpd.conf
 #Run Ansible playbook for Frontend deployment using provided inputs
-/usr/local/bin/ansible-playbook /root/xmladmin_deployment.yml -e '${ANSIBLE_INPUTS}'
+$${GET_PARAM_COMMAND} '${ANSIBLE_INPUTS_PATH}' > /root/ansible_inputs.json
+echo "Deploying ${APP_VERSION}"
+/usr/local/bin/ansible-playbook /root/xmladmin_deployment.yml -e '@/root/ansible_inputs.json'

--- a/groups/adminsites-infrastructure/templates/xmloutadmin_user_data.tpl
+++ b/groups/adminsites-infrastructure/templates/xmloutadmin_user_data.tpl
@@ -2,10 +2,10 @@
 # Redirect the user-data output to the console logs
 exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 
+GET_PARAM_COMMAND="/usr/local/bin/aws ssm get-parameter --with-decryption --region ${REGION} --output text --query Parameter.Value --name"
+
 #Create key:value variable
-cat <<EOF >>inputs.json
-${FRONTEND_INPUTS}
-EOF
+$${GET_PARAM_COMMAND} '${FRONTEND_INPUTS_PATH}' > inputs.json
 #Update Nagios registration script with relevant template
 cp /usr/local/bin/nagios-host-add.sh /usr/local/bin/nagios-host-add.j2
 REPLACE=Admin_Site_${HERITAGE_ENVIRONMENT} /usr/local/bin/j2 /usr/local/bin/nagios-host-add.j2 > /usr/local/bin/nagios-host-add.sh
@@ -18,4 +18,6 @@ rm /etc/httpd/conf.d/perl.conf
 #Create and populate httpd config
 /usr/local/bin/j2 -f json /etc/httpd/conf/xmloutadmin.httpd.conf.j2 inputs.json > /etc/httpd/conf/httpd.conf
 #Run Ansible playbook for Frontend deployment using provided inputs
-/usr/local/bin/ansible-playbook /root/xmloutadmin_deployment.yml -e '${ANSIBLE_INPUTS}'
+$${GET_PARAM_COMMAND} '${ANSIBLE_INPUTS_PATH}' > /root/ansible_inputs.json
+echo "Deploying ${APP_VERSION}"
+/usr/local/bin/ansible-playbook /root/xmloutadmin_deployment.yml -e '@/root/ansible_inputs.json'

--- a/groups/adminsites-infrastructure/variables.tf
+++ b/groups/adminsites-infrastructure/variables.tf
@@ -131,7 +131,7 @@ variable "cw_logs" {
 
 variable "ami_name" {
   type        = string
-  default     = "admin-sites-0.1.26"
+  default     = "admin-sites-*"
   description = "Name of the AMI to use in the Auto Scaling configuration for frontend server(s)"
 }
 

--- a/groups/adminsites-infrastructure/variables.tf
+++ b/groups/adminsites-infrastructure/variables.tf
@@ -131,7 +131,7 @@ variable "cw_logs" {
 
 variable "ami_name" {
   type        = string
-  default     = "admin-sites-*"
+  default     = "admin-sites-0.1.26"
   description = "Name of the AMI to use in the Auto Scaling configuration for frontend server(s)"
 }
 


### PR DESCRIPTION
The admin sites EC2 instances contain sensitive data within the user data on the heritage-staging and heritage-live accounts.

This change is to avoid embedding the sensitive data in the user data script and instead use parameter store, and access the data from there when the script runs.

Resolves:
https://companieshouse.atlassian.net/browse/DVOP-2776