### PR TITLE
Adding CHD admin to admin-site Repo

### DIFF
--- a/groups/adminsites-infrastructure/autoscaling-group-chdadmin.tf
+++ b/groups/adminsites-infrastructure/autoscaling-group-chdadmin.tf
@@ -61,7 +61,7 @@ module "chdadmin_autoscaling_groups" {
   termination_policies           = ["OldestLaunchConfiguration"]
   target_group_arns              = [for group in module.adminsites_internal_alb.target_group_arns : group if can(regex("chdadmin", group))]
   iam_instance_profile           = module.chdadmin_iam_profile.aws_iam_instance_profile.name
-  user_data_base64               = data.cloudinit_config.ewfadmin.rendered
+  user_data_base64               = data.cloudinit_config.chdadmin.rendered
 
   tags_as_map = merge(
     local.default_tags,

--- a/groups/adminsites-infrastructure/autoscaling-group-chdadmin.tf
+++ b/groups/adminsites-infrastructure/autoscaling-group-chdadmin.tf
@@ -59,7 +59,7 @@ module "chdadmin_autoscaling_groups" {
   refresh_triggers               = ["launch_configuration"]
   key_name                       = aws_key_pair.adminsites_keypair.key_name
   termination_policies           = ["OldestLaunchConfiguration"]
-  target_group_arns              = [[for group in module.adminsites_internal_alb.target_group_arns : group if can(regex("chdadmin", group))]]
+  target_group_arns              = [for group in module.adminsites_internal_alb.target_group_arns : group if can(regex("chdadmin", group))]
   iam_instance_profile           = module.chdadmin_iam_profile.aws_iam_instance_profile.name
   user_data_base64               = data.cloudinit_config.ewfadmin.rendered
 

--- a/groups/adminsites-infrastructure/autoscaling-group-chdadmin.tf
+++ b/groups/adminsites-infrastructure/autoscaling-group-chdadmin.tf
@@ -1,0 +1,101 @@
+# ASG Scheduled Shutdown for non-production
+resource "aws_autoscaling_schedule" "chdadmin_schedule_stop" {
+  count = var.environment == "live" ? 0 : 1
+
+  scheduled_action_name  = "${var.aws_account}-${var.application}-chdadmin-scheduled-shutdown"
+  min_size               = 0
+  max_size               = 0
+  desired_capacity       = 0
+  recurrence             = "00 20 * * 1-5" #Mon-Fri at 8pm
+  autoscaling_group_name = module.chdadmin_autoscaling_groups.this_autoscaling_group_name
+}
+
+# ASG Scheduled Startup for non-production
+resource "aws_autoscaling_schedule" "chdadmin_schedule_start" {
+  count = var.environment == "live" ? 0 : 1
+  
+  scheduled_action_name  = "${var.aws_account}-${var.application}-chdadmin-scheduled-startup"
+  min_size               = var.min_size
+  max_size               = var.max_size
+  desired_capacity       = var.desired_capacity
+  recurrence             = "00 06 * * 1-5" #Mon-Fri at 6am
+  autoscaling_group_name = module.chdadmin_autoscaling_groups.this_autoscaling_group_name
+}  
+
+# ASG Module
+module "chdadmin_autoscaling_groups" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/terraform-aws-autoscaling?ref=tags/1.0.357"
+
+  name = "chdadmin-webserver"
+  # Launch configuration
+  lc_name       = "chdadmin-launchconfig"
+  image_id      = data.aws_ami.adminsites.id
+  instance_type = var.instance_size
+  security_groups = [
+    module.adminsites_asg_security_group.security_group_id,
+    data.aws_security_group.nagios_shared.id
+  ]
+  root_block_device = [
+    {
+      volume_size = "40"
+      volume_type = "gp3"
+      encrypted   = true
+      iops        = "3000"
+      throughput  = "125"
+    },
+  ]
+  # Auto scaling group
+  asg_name                       = "chdadmin-asg"
+  vpc_zone_identifier            = data.aws_subnets.web.ids
+  health_check_type              = "ELB"
+  min_size                       = var.min_size
+  max_size                       = var.max_size
+  desired_capacity               = var.desired_capacity
+  health_check_grace_period      = 300
+  wait_for_capacity_timeout      = 0
+  force_delete                   = true
+  enable_instance_refresh        = true
+  refresh_min_healthy_percentage = 50
+  refresh_triggers               = ["launch_configuration"]
+  key_name                       = aws_key_pair.adminsites_keypair.key_name
+  termination_policies           = ["OldestLaunchConfiguration"]
+  target_group_arns              = [[for group in module.adminsites_internal_alb.target_group_arns : group if can(regex("chdadmin", group))]]
+  iam_instance_profile           = module.chdadmin_iam_profile.aws_iam_instance_profile.name
+  user_data_base64               = data.cloudinit_config.ewfadmin.rendered
+
+  tags_as_map = merge(
+    local.default_tags,
+    {
+      Name        = "chdadmin-webserver"
+      ServiceTeam = "${upper(var.application)}-FE-Support"
+    }
+  )
+}
+
+#--------------------------------------------
+# CHD Admin CloudWatch Alarms
+#--------------------------------------------
+module "chdadmin__autoscaling_groups_alarms" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/asg-cloudwatch-alarms?ref=tags/1.0.357"
+  
+  autoscaling_group_name = module.chdadmin_autoscaling_groups.this_autoscaling_group_name
+  prefix                 = "chdadmin-asg-alarms"
+  in_service_evaluation_periods      = "3"
+  in_service_statistic_period        = "120"
+  expected_instances_in_service      = var.desired_capacity
+  in_pending_evaluation_periods      = "3"
+  in_pending_statistic_period        = "120"
+  in_standby_evaluation_periods      = "3"
+  in_standby_statistic_period        = "120"
+  in_terminating_evaluation_periods  = "3"
+  in_terminating_statistic_period    = "120"
+  total_instances_evaluation_periods = "3"
+  total_instances_statistic_period   = "120"
+  total_instances_in_service         = var.desired_capacity
+
+  actions_alarm = var.enable_sns_topic ? [module.cloudwatch_sns_notifications[0].sns_topic_arn] : []
+  actions_ok    = var.enable_sns_topic ? [module.cloudwatch_sns_notifications[0].sns_topic_arn] : []
+}
+
+
+

--- a/groups/adminsites-infrastructure/cloudwatch.tf
+++ b/groups/adminsites-infrastructure/cloudwatch.tf
@@ -45,3 +45,19 @@ resource "aws_cloudwatch_log_group" "xmloutadmin" {
     }
   )
 }
+
+resource "aws_cloudwatch_log_group" "chdadmin" {
+  for_each = local.chdadmin_cw_logs
+
+  name              = each.value["log_group_name"]
+  retention_in_days = lookup(each.value, "log_group_retention", var.default_log_group_retention_in_days)
+  kms_key_id        = lookup(each.value, "kms_key_id", local.logs_kms_key_id)
+
+  tags = merge(
+    local.default_tags,
+    {
+      Name        = each.value["log_group_name"]
+      ServiceTeam = "${upper(var.application)}-FE-Support"
+    }
+  )
+}

--- a/groups/adminsites-infrastructure/data.tf
+++ b/groups/adminsites-infrastructure/data.tf
@@ -112,17 +112,6 @@ data "aws_ami" "adminsites" {
 # ------------------------------------------------------------------------------
 # EWF Admin data
 # ------------------------------------------------------------------------------
-data "template_file" "ewfadmin" {
-  template = file("${path.module}/templates/ewfadmin_user_data.tpl")
-
-  vars = {
-    REGION               = var.aws_region
-    HERITAGE_ENVIRONMENT = title(var.environment)
-    APP_VERSION          = var.ewfadmin_app_release_version
-    FRONTEND_INPUTS_PATH = "${local.parameter_store_path_prefix}/ewfadmin_frontend_inputs"
-    ANSIBLE_INPUTS_PATH  = "${local.parameter_store_path_prefix}/ewfadmin_frontend_ansible_inputs"
-  }
-}
 
 data "cloudinit_config" "ewfadmin" {
   gzip          = true
@@ -130,24 +119,19 @@ data "cloudinit_config" "ewfadmin" {
 
   part {
     content_type = "text/x-shellscript"
-    content      = data.template_file.ewfadmin.rendered
+    content      = templatefile("${path.module}/templates/ewfadmin_user_data.tpl", {
+      REGION               = var.aws_region
+      HERITAGE_ENVIRONMENT = title(var.environment)
+      APP_VERSION          = var.ewfadmin_app_release_version
+      FRONTEND_INPUTS_PATH = "${local.parameter_store_path_prefix}/ewfadmin_frontend_inputs"
+      ANSIBLE_INPUTS_PATH  = "${local.parameter_store_path_prefix}/ewfadmin_frontend_ansible_inputs"
+    })
   }
 }
 
 # ------------------------------------------------------------------------------
 # XML Admin data
 # ------------------------------------------------------------------------------
-data "template_file" "xmladmin" {
-  template = file("${path.module}/templates/xmladmin_user_data.tpl")
-
-  vars = {
-    REGION               = var.aws_region
-    HERITAGE_ENVIRONMENT = title(var.environment)
-    APP_VERSION          = var.xmladmin_app_release_version
-    FRONTEND_INPUTS_PATH = "${local.parameter_store_path_prefix}/xmladmin_frontend_inputs"
-    ANSIBLE_INPUTS_PATH  = "${local.parameter_store_path_prefix}/xmladmin_frontend_ansible_inputs"
-  }
-}
 
 data "cloudinit_config" "xmladmin" {
   gzip          = true
@@ -155,24 +139,19 @@ data "cloudinit_config" "xmladmin" {
 
   part {
     content_type = "text/x-shellscript"
-    content      = data.template_file.xmladmin.rendered
+    content      = templatefile("${path.module}/templates/xmladmin_user_data.tpl", {
+      REGION               = var.aws_region
+      HERITAGE_ENVIRONMENT = title(var.environment)
+      APP_VERSION          = var.xmladmin_app_release_version
+      FRONTEND_INPUTS_PATH = "${local.parameter_store_path_prefix}/xmladmin_frontend_inputs"
+      ANSIBLE_INPUTS_PATH  = "${local.parameter_store_path_prefix}/xmladmin_frontend_ansible_inputs"
+    })
   }
 }
 
 # ------------------------------------------------------------------------------
 # XMLOUT Admin data
 # ------------------------------------------------------------------------------
-data "template_file" "xmloutadmin" {
-  template = file("${path.module}/templates/xmloutadmin_user_data.tpl")
-
-  vars = {
-    REGION               = var.aws_region
-    HERITAGE_ENVIRONMENT = title(var.environment)
-    APP_VERSION          = var.xmloutadmin_app_release_version
-    FRONTEND_INPUTS_PATH = "${local.parameter_store_path_prefix}/xmloutadmin_frontend_inputs"
-    ANSIBLE_INPUTS_PATH  = "${local.parameter_store_path_prefix}/xmloutadmin_frontend_ansible_inputs"
-  }
-}
 
 data "cloudinit_config" "xmloutadmin" {
   gzip          = true
@@ -180,7 +159,13 @@ data "cloudinit_config" "xmloutadmin" {
 
   part {
     content_type = "text/x-shellscript"
-    content      = data.template_file.xmloutadmin.rendered
+    content      = templatefile("${path.module}/templates/xmloutadmin_user_data.tpl", {
+      REGION               = var.aws_region
+      HERITAGE_ENVIRONMENT = title(var.environment)
+      APP_VERSION          = var.xmloutadmin_app_release_version
+      FRONTEND_INPUTS_PATH = "${local.parameter_store_path_prefix}/xmloutadmin_frontend_inputs"
+      ANSIBLE_INPUTS_PATH  = "${local.parameter_store_path_prefix}/xmloutadmin_frontend_ansible_inputs"
+    })
   }
 }
 
@@ -188,24 +173,18 @@ data "cloudinit_config" "xmloutadmin" {
 # CHD Admin data
 # ------------------------------------------------------------------------------
 
-data "template_file" "chdadmin" {
-  template = file("${path.module}/templates/chdadmin_user_data.tpl")
-
-  vars = {
-    REGION               = var.aws_region
-    HERITAGE_ENVIRONMENT = title(var.environment)
-    APP_VERSION          = var.chdadmin_app_release_version
-    FRONTEND_INPUTS_PATH = "${local.parameter_store_path_prefix}/chdadmin_frontend_inputs"
-    ANSIBLE_INPUTS_PATH  = "${local.parameter_store_path_prefix}/chdadmin_frontend_ansible_inputs"
-  }
-}
-
 data "cloudinit_config" "chdadmin" {
   gzip          = true
   base64_encode = true
 
   part {
     content_type = "text/x-shellscript"
-    content      = data.template_file.chdadmin.rendered
+    content      = templatefile("${path.module}/templates/chdadmin_user_data.tpl", {
+      REGION               = var.aws_region
+      HERITAGE_ENVIRONMENT = title(var.environment)
+      APP_VERSION          = var.chdadmin_app_release_version
+      FRONTEND_INPUTS_PATH = "${local.parameter_store_path_prefix}/chdadmin_frontend_inputs"
+      ANSIBLE_INPUTS_PATH  = "${local.parameter_store_path_prefix}/chdadmin_frontend_ansible_inputs"
+    })
   }
 }

--- a/groups/adminsites-infrastructure/data.tf
+++ b/groups/adminsites-infrastructure/data.tf
@@ -80,6 +80,10 @@ data "vault_generic_secret" "xmloutadmin_data" {
   path = "applications/${var.aws_account}-${var.aws_region}/${replace(var.application, "-", "")}/xmloutadmin"
 }
 
+data "vault_generic_secret" "chdadmin_data" {
+  path = "applications/${var.aws_account}-${var.aws_region}/${replace(var.application, "-", "")}/chdadmin"
+} 
+
 
 
 data "aws_acm_certificate" "acm_cert" {
@@ -177,5 +181,31 @@ data "cloudinit_config" "xmloutadmin" {
   part {
     content_type = "text/x-shellscript"
     content      = data.template_file.xmloutadmin.rendered
+  }
+}
+
+# ------------------------------------------------------------------------------
+# CHD Admin data
+# ------------------------------------------------------------------------------
+
+data "template_file" "chdadmin" {
+  template = file("${path.module}/templates/chdadmin_user_data.tpl")
+
+  vars = {
+    REGION               = var.aws_region
+    HERITAGE_ENVIRONMENT = title(var.environment)
+    APP_VERSION          = var.chdadmin_app_release_version
+    FRONTEND_INPUTS_PATH = "${local.parameter_store_path_prefix}/chdadmin_frontend_inputs"
+    ANSIBLE_INPUTS_PATH  = "${local.parameter_store_path_prefix}/chdadmin_frontend_ansible_inputs"
+  }
+}
+
+data "cloudinit_config" "chdadmin" {
+  gzip          = true
+  base64_encode = true
+
+  part {
+    content_type = "text/x-shellscript"
+    content      = data.template_file.chdadmin.rendered
   }
 }

--- a/groups/adminsites-infrastructure/iam.tf
+++ b/groups/adminsites-infrastructure/iam.tf
@@ -150,3 +150,54 @@ module "xmloutadmin_iam_profile" {
     }
   ]
 }
+
+module "chdadmin_iam_profile" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/instance_profile?ref=tags/1.0.357"
+
+  name       = "chdadmin-profile"
+  enable_ssm = true
+  cw_log_group_arns = length(local.chdadmin_log_groups) > 0 ? flatten([
+    formatlist(
+      "arn:aws:logs:%s:%s:log-group:%s:*:*",
+      var.aws_region,
+      data.aws_caller_identity.current.account_id,
+      local.chdadmin_log_groups
+    ),
+    formatlist("arn:aws:logs:%s:%s:log-group:%s:*",
+      var.aws_region,
+      data.aws_caller_identity.current.account_id,
+      local.chdadmin_log_groups
+    ),
+  ]) : null
+  instance_asg_arns = [module.chdadmin_autoscaling_groups.this_autoscaling_group_arn]
+  kms_key_refs = [
+    "alias/${var.account}/${var.region}/ebs",
+    local.ssm_kms_key_id,
+    local.account_ssm_key_arn
+  ]
+  s3_buckets_write = [local.session_manager_bucket_name]
+  custom_statements = [
+    {
+      sid    = "AllowAccessToReleaseBucket",
+      effect = "Allow",
+      resources = [
+        "arn:aws:s3:::shared-services.eu-west-2.releases.ch.gov.uk/*",
+        "arn:aws:s3:::shared-services.eu-west-2.releases.ch.gov.uk",
+        "arn:aws:s3:::shared-services.eu-west-2.configs.ch.gov.uk/*",
+        "arn:aws:s3:::shared-services.eu-west-2.configs.ch.gov.uk"
+      ],
+      actions = [
+        "s3:Get*",
+        "s3:List*",
+      ]
+    },
+    {
+      sid       = "AllowReadOfParameterStore",
+      effect    = "Allow",
+      resources = ["arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/${var.application}/${var.environment}/*"],
+      actions = [
+        "ssm:GetParameter*"
+      ]
+    }
+  ]
+}

--- a/groups/adminsites-infrastructure/locals.tf
+++ b/groups/adminsites-infrastructure/locals.tf
@@ -20,7 +20,8 @@ locals {
   sites = [
     "ewfadmin",
     "xmladmin",
-    "xmloutadmin"
+    "xmloutadmin",
+    "chdadmin"
   ]
 
   #################################
@@ -31,10 +32,12 @@ locals {
   ewfadmin_cw_logs    = { for log, map in merge(var.cw_logs, var.ewfadmin_custom_logs) : log => merge(map, { "log_group_name" = "ewfadmin-${log}" }) }
   xmladmin_cw_logs    = { for log, map in merge(var.cw_logs, var.xmladmin_custom_logs) : log => merge(map, { "log_group_name" = "xmladmin-${log}" }) }
   xmloutadmin_cw_logs = { for log, map in merge(var.cw_logs, var.xmloutadmin_custom_logs) : log => merge(map, { "log_group_name" = "xmloutadmin-${log}" }) }
+  chdadmin_cw_logs    = { for log, map in merge(var.cw_logs, var.chdadmin_custom_logs) : log => merge(map, { "log_group_name" = "chdadmin-${log}" }) }
 
   ewfadmin_log_groups    = compact([for log, map in local.ewfadmin_cw_logs : lookup(map, "log_group_name", "")])
   xmladmin_log_groups    = compact([for log, map in local.xmladmin_cw_logs : lookup(map, "log_group_name", "")])
   xmloutadmin_log_groups = compact([for log, map in local.xmloutadmin_cw_logs : lookup(map, "log_group_name", "")])
+  chdadmin_log_groups    = compact([for log, map in local.chdadmin_cw_logs : lookup(map, "log_group_name", "")])
 
   ################################
 
@@ -78,6 +81,19 @@ locals {
     cw_agent_user              = "root"
   }
 
+  chdadmin_ansible_inputs = {
+    s3_bucket_releases         = local.s3_releases["release_bucket_name"]
+    s3_bucket_configs          = local.s3_releases["config_bucket_name"]
+    heritage_environment       = var.environment
+    version                    = var.chdadmin_app_release_version
+    default_nfs_server_address = var.nfs_server
+    mounts_parent_dir          = var.nfs_mount_destination_parent_dir
+    mounts                     = var.nfs_mounts
+    region                     = var.aws_region
+    cw_log_files               = local.chdadmin_cw_logs
+    cw_agent_user              = "root"
+  }
+
   parameter_store_path_prefix = "/${var.application}/${var.environment}"
 
   parameter_store_secrets = {
@@ -87,6 +103,8 @@ locals {
     xmladmin_frontend_ansible_inputs    = jsonencode(local.xmladmin_ansible_inputs)
     xmloutadmin_frontend_inputs         = data.vault_generic_secret.xmloutadmin_data.data_json
     xmloutadmin_frontend_ansible_inputs = jsonencode(local.xmloutadmin_ansible_inputs)
+    chdadmin_frontend_inputs            = data.vault_generic_secret.chdadmin_data.data_json
+    chdadmin_frontend_ansible_inputs    = jsonencode(local.chdadmin_ansible_inputs)
   }
 
   ################################

--- a/groups/adminsites-infrastructure/main.tf
+++ b/groups/adminsites-infrastructure/main.tf
@@ -18,6 +18,11 @@ terraform {
       source  = "hashicorp/cloudinit"
       version = ">= 2.0, < 3.0"
     }
+
+    template = {
+      source  = "hashicorp/template"
+      version = "2.2.0"
+    }
   }
   backend "s3" {}
 }

--- a/groups/adminsites-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/adminsites-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -70,8 +70,8 @@ cw_logs = {
 
 ewfadmin_custom_logs = {
   "ewfadm_access_log" = {
-  file_path = "/var/log/httpd"
-  log_group_retention = 7
+    file_path = "/var/log/httpd"
+    log_group_retention = 7
   }
 
   "ewfadm_error_log" = {
@@ -82,8 +82,8 @@ ewfadmin_custom_logs = {
 
 xmladmin_custom_logs = {
   "xmladm_access_log" = {
-  file_path = "/var/log/httpd"
-  log_group_retention = 7
+    file_path = "/var/log/httpd"
+    log_group_retention = 7
   }
 
   "xmladm_error_log" = {
@@ -94,8 +94,8 @@ xmladmin_custom_logs = {
 
 xmloutadmin_custom_logs = {
   "xmloutadm_access_log" = {
-  file_path = "/var/log/httpd"
-  log_group_retention = 7
+    file_path = "/var/log/httpd"
+    log_group_retention = 7
   }
 
   "xmloutadm_error_log" = {
@@ -106,12 +106,12 @@ xmloutadmin_custom_logs = {
 
 chdadmin_custom_logs = {
   "chdadm_access_log" = {
-  file_path = "/var/log/httpd"
-  log_group_retention = 7
+    file_path = "/var/log/httpd"
+    log_group_retention = 7
   }
 
   "chdadm_error_log" = {
     file_path = "/var/log/httpd"
     log_group_retention = 7
   }
-} 
+}

--- a/groups/adminsites-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/adminsites-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -103,3 +103,15 @@ xmloutadmin_custom_logs = {
     log_group_retention = 7
   }
 }
+
+chdadmin_custom_logs = {
+  "chdadm_access_log" = {
+  file_path = "/var/log/httpd"
+  log_group_retention = 7
+  }
+
+  "chdadm_error_log" = {
+    file_path = "/var/log/httpd"
+    log_group_retention = 7
+  }
+} 

--- a/groups/adminsites-infrastructure/profiles/heritage-live-eu-west-2/vars
+++ b/groups/adminsites-infrastructure/profiles/heritage-live-eu-west-2/vars
@@ -70,8 +70,8 @@ cw_logs = {
 
 ewfadmin_custom_logs = {
   "ewfadm_access_log" = {
-  file_path = "/var/log/httpd"
-  log_group_retention = 7
+    file_path = "/var/log/httpd"
+    log_group_retention = 7
   }
 
   "ewfadm_error_log" = {
@@ -82,8 +82,8 @@ ewfadmin_custom_logs = {
 
 xmladmin_custom_logs = {
   "xmladm_access_log" = {
-  file_path = "/var/log/httpd"
-  log_group_retention = 7
+    file_path = "/var/log/httpd"
+    log_group_retention = 7
   }
 
   "xmladm_error_log" = {
@@ -94,11 +94,23 @@ xmladmin_custom_logs = {
 
 xmloutadmin_custom_logs = {
   "xmloutadm_access_log" = {
-  file_path = "/var/log/httpd"
-  log_group_retention = 7
+    file_path = "/var/log/httpd"
+    log_group_retention = 7
   }
 
   "xmloutadm_error_log" = {
+    file_path = "/var/log/httpd"
+    log_group_retention = 7
+  }
+}
+
+chdadmin_custom_logs = {
+  "chdadm_access_log" = {
+    file_path = "/var/log/httpd"
+    log_group_retention = 7
+  }
+
+  "chdadm_error_log" = {
     file_path = "/var/log/httpd"
     log_group_retention = 7
   }

--- a/groups/adminsites-infrastructure/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/adminsites-infrastructure/profiles/heritage-staging-eu-west-2/vars
@@ -70,8 +70,8 @@ cw_logs = {
 
 ewfadmin_custom_logs = {
   "ewfadm_access_log" = {
-  file_path = "/var/log/httpd"
-  log_group_retention = 7
+    file_path = "/var/log/httpd"
+    log_group_retention = 7
   }
 
   "ewfadm_error_log" = {
@@ -82,8 +82,8 @@ ewfadmin_custom_logs = {
 
 xmladmin_custom_logs = {
   "xmladm_access_log" = {
-  file_path = "/var/log/httpd"
-  log_group_retention = 7
+    file_path = "/var/log/httpd"
+    log_group_retention = 7
   }
 
   "xmladm_error_log" = {
@@ -94,11 +94,23 @@ xmladmin_custom_logs = {
 
 xmloutadmin_custom_logs = {
   "xmloutadm_access_log" = {
-  file_path = "/var/log/httpd"
-  log_group_retention = 7
+    file_path = "/var/log/httpd"
+    log_group_retention = 7
   }
 
   "xmloutadm_error_log" = {
+    file_path = "/var/log/httpd"
+    log_group_retention = 7
+  }
+}
+
+chdadmin_custom_logs = {
+  "chdadm_access_log" = {
+    file_path = "/var/log/httpd"
+    log_group_retention = 7
+  }
+
+  "chdadm_error_log" = {
     file_path = "/var/log/httpd"
     log_group_retention = 7
   }

--- a/groups/adminsites-infrastructure/templates/chdadmin_user_data.tpl
+++ b/groups/adminsites-infrastructure/templates/chdadmin_user_data.tpl
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Redirect the user-data output to the console logs
+exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+
+GET_PARAM_COMMAND="/usr/local/bin/aws ssm get-parameter --with-decryption --region ${REGION} --output text --query Parameter.Value --name"
+
+#Create key:value variable
+$${GET_PARAM_COMMAND} '${FRONTEND_INPUTS_PATH}' > inputs.json
+#Update Nagios registration script with relevant template
+cp /usr/local/bin/nagios-host-add.sh /usr/local/bin/nagios-host-add.j2
+REPLACE=Admin_Site_${HERITAGE_ENVIRONMENT} /usr/local/bin/j2 /usr/local/bin/nagios-host-add.j2 > /usr/local/bin/nagios-host-add.sh
+#Create the TNSNames.ora file for Oracle
+/usr/local/bin/j2 -f json /usr/lib/oracle/11.2/client64/lib/tnsnames.j2 inputs.json > /usr/lib/oracle/11.2/client64/lib/tnsnames.ora
+#Remove unnecessary files
+rm /etc/httpd/conf.d/welcome.conf
+rm /etc/httpd/conf.d/ssl.conf
+rm /etc/httpd/conf.d/perl.conf
+#Create and populate httpd config
+/usr/local/bin/j2 -f json /etc/httpd/conf/chdadmin.httpd.conf.j2 inputs.json > /etc/httpd/conf/httpd.conf
+#Run Ansible playbook for Frontend deployment using provided inputs
+$${GET_PARAM_COMMAND} '${ANSIBLE_INPUTS_PATH}' > /root/ansible_inputs.json
+echo "Deploying ${APP_VERSION}"
+/usr/local/bin/ansible-playbook /root/chdadmin_deployment.yml -e '@/root/ansible_inputs.json'

--- a/groups/adminsites-infrastructure/variables.tf
+++ b/groups/adminsites-infrastructure/variables.tf
@@ -186,3 +186,17 @@ variable "xmloutadmin_custom_logs" {
   description = "Map of log file information for XMLOUT Admin specifically; used to create log groups, IAM permissions and passed to the application to configure remote logging"
   default     = {}
 }
+
+# ------------------------------------------------------------------------------
+# XMLOUT Admin Variables
+# ------------------------------------------------------------------------------
+variable "chdadmin_app_release_version" {
+  type        = string
+  description = "Version of the application to download for deployment to frontend server(s)"
+}
+
+variable "chdadmin_custom_logs" {
+  type        = map(any)
+  description = "Map of log file information for CHD Admin specifically; used to create log groups, IAM permissions and passed to the application to configure remote logging"
+  default     = {}
+}

--- a/groups/adminsites-infrastructure/variables.tf
+++ b/groups/adminsites-infrastructure/variables.tf
@@ -188,7 +188,7 @@ variable "xmloutadmin_custom_logs" {
 }
 
 # ------------------------------------------------------------------------------
-# XMLOUT Admin Variables
+# CHD Admin Variables
 # ------------------------------------------------------------------------------
 variable "chdadmin_app_release_version" {
   type        = string


### PR DESCRIPTION
This PR adds CHD Admin support to the admin-sites-terraform repository with the following changes:

**New Files:** 

- `autoscaling-group-chdadmin.tf` ASG with scheduled shutdown for non-production, ASG module, and CloudWatch alarms for autoscaler triggers
- `templates/chdadmin_user_data.tpl` template that configures user data, updates registration scripts, creates TNS files, and runs Ansible playbooks for frontend deployment

**Modified Files:**

- `cloudwatch.tf `— Added CHD Admin log group with retention settings and log lookups
- `data.tf` — Added Cloud Init configuration for CHD Admin and user data template script
- `iam.tf `— Added IAM profile for CHD Admin
- `locals.tf` — Added Ansible user inputs for CHD Admin including buckets, environment, version, mount points, CloudWatch logs, and frontend inputs
- `variables.tf `— Added CHD custom logs and CHD app release version variables

