### PR TITLE
Disable Tenable CWP Scan

### DIFF
--- a/groups/adminsites-infrastructure/autoscaling-group-chdadmin.tf
+++ b/groups/adminsites-infrastructure/autoscaling-group-chdadmin.tf
@@ -66,8 +66,10 @@ module "chdadmin_autoscaling_groups" {
   tags_as_map = merge(
     local.default_tags,
     {
-      Name        = "chdadmin-webserver"
-      ServiceTeam = "${upper(var.application)}-FE-Support"
+      Name                       = "chdadmin-webserver"
+      ServiceTeam                = "${upper(var.application)}-FE-Support"
+      tenable-cwp-scan-disabled  = "true"
+      Repository                 = "admin-sites-terraform"
     }
   )
 }

--- a/groups/adminsites-infrastructure/autoscaling-group-ewfadmin.tf
+++ b/groups/adminsites-infrastructure/autoscaling-group-ewfadmin.tf
@@ -66,8 +66,10 @@ module "ewfadmin_autoscaling_groups" {
   tags_as_map = merge(
     local.default_tags,
     {
-      Name        = "ewfadmin-webserver"
-      ServiceTeam = "${upper(var.application)}-FE-Support"
+      Name                       = "ewfadmin-webserver"
+      ServiceTeam                = "${upper(var.application)}-FE-Support"
+      tenable-cwp-scan-disabled  = "true"
+      Repository                 = "admin-sites-terraform"
     }
   )
 }

--- a/groups/adminsites-infrastructure/autoscaling-group-xmladmin.tf
+++ b/groups/adminsites-infrastructure/autoscaling-group-xmladmin.tf
@@ -66,8 +66,10 @@ module "xmladmin_autoscaling_groups" {
   tags_as_map = merge(
     local.default_tags,
     {
-      Name        = "xmladmin-webserver"
-      ServiceTeam = "${upper(var.application)}-FE-Support"
+      Name                       = "xmladmin-webserver"
+      ServiceTeam                = "${upper(var.application)}-FE-Support"
+      tenable-cwp-scan-disabled  = "true"
+      Repository                 = "admin-sites-terraform"
     }
   )
 

--- a/groups/adminsites-infrastructure/autoscaling-group-xmloutadmin.tf
+++ b/groups/adminsites-infrastructure/autoscaling-group-xmloutadmin.tf
@@ -66,8 +66,10 @@ module "xmloutadmin_autoscaling_groups" {
   tags_as_map = merge(
     local.default_tags,
     {
-      Name        = "xmloutadmin-webserver"
-      ServiceTeam = "${upper(var.application)}-FE-Support"
+      Name                       = "xmloutadmin-webserver"
+      ServiceTeam                = "${upper(var.application)}-FE-Support"
+      tenable-cwp-scan-disabled  = "true"
+      Repository                 = "admin-sites-terraform"
     }
   )
 


### PR DESCRIPTION
This is for [DVOP-4517](https://companieshouse.atlassian.net/browse/DVOP-4517)

There is an issue where workload scanning cannot run on certain instances either due to licensing restrictions or the workload doesn't support the scanner.

Once they have been excluded, inspector will be ingested into tenable ([DVOP-4853](https://companieshouse.atlassian.net/browse/DVOP-4853)) instead to restore the data and circumvent the workload scanning issues

[DVOP-4517]: https://companieshouse.atlassian.net/browse/DVOP-4517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DVOP-4853]: https://companieshouse.atlassian.net/browse/DVOP-4853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ